### PR TITLE
Reduce ignore time to 30 days and delete expired ignores

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,3 +12,12 @@ workflows:
             # Trigger job also on git tag.
             tags:
               only: /^v.*/
+
+      - architect/push-to-registries:
+          context: architect
+          name: push-to-registries
+          requires:
+            - go-build
+          filters:
+            tags:
+              only: /^v.*/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Reduce ignores expiration time to 30 days.
+- Remove ignores when expired.
+
 ## [0.3.1] - 2024-01-19
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ LABEL "repository"="https://github.com/giantswarm/nancy-fixer"
 ADD https://github.com/sonatype-nexus-community/nancy/releases/download/v1.0.45/nancy-v1.0.45-linux-amd64 /usr/local/bin/nancy
 RUN chmod a+x /usr/local/bin/nancy
 
-RUN go install github.com/giantswarm/nancy-fixer@v0.3.1
+RUN go install github.com/giantswarm/nancy-fixer@v0.4.0
 
 ADD entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/pkg/nancy/ignore.go
+++ b/pkg/nancy/ignore.go
@@ -9,7 +9,7 @@ import (
 	"github.com/giantswarm/microerror"
 )
 
-const DefaultIgnorePeriodDays = 90
+const DefaultIgnorePeriodDays = 30
 
 func IgnoreVulnerabilities(
 	vulnerabilities []Vulnerability,


### PR DESCRIPTION
A bit better than before, not perfect yet but I'm happy with it. Now the expired ignores are deleted and the new expiry dates are only 30 days in the future. We need to add a cleanup since unused ignores are not deleted until they expire.