### PR TITLE
Restrict Go dependency listing to current project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-
-
 ## [Unreleased]
+
+- Fix dependency gathering for `nancy sleuth` to unly use return Go modules used in the current project (`go list -json -deps ./...`). Before, all Go modules in the environment were used (`go list -json -deps all`).
 
 ## [0.4.3] - 2024-02-06
 

--- a/pkg/nancy/nancy.go
+++ b/pkg/nancy/nancy.go
@@ -113,7 +113,7 @@ func RunSleuth(dir string) (NancySleuthOutputJSON, error) {
 	r, w := io.Pipe()
 	goCmd := exec.Cmd{
 		Path:   goExecutable,
-		Args:   []string{goExecutable, "list", "-json", "-m", "all"},
+		Args:   []string{goExecutable, "list", "-json", "-deps", "./..."},
 		Dir:    dir,
 		Stdout: w,
 	}


### PR DESCRIPTION
### What does this PR do?

This PR changes the command used for dependency listing from

    go list -json -m all

to

    go list -json -deps ./...

Before, the program would try to mitigate security vulnerabilities in projects that were not used in the current Go project at all, resulting ion `replace` directives and `.nancy-ignore` entries for modules that were in fact not used.

We have fixed the same mistake in our CI jobs already in https://github.com/giantswarm/devctl/pull/680 .

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)
