### PR TITLE
Fix problem where nancy exits with code 1, without error message in giantswarm/devctl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- More debug logging, especially in case of errors.
+- The environment variable `LOG_LEVEL` can be used to set the log level when executing the container image.
+
 ### Changed
 
 - Resolve updated code linter findings.
+- Nancy bumped to v1.0.48
 
 ## [0.5.0] - 2025-05-14
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24
+FROM gsoci.azurecr.io/giantswarm/golang:1.24
 
 LABEL "com.github.actions.name"="nancy-fixer-action"
 LABEL "com.github.actions.description"="runs nancy-fixer to patch vulnerabilities found by Nancy"
@@ -6,7 +6,7 @@ LABEL "com.github.actions.icon"="shield"
 LABEL "com.github.actions.color"="orange"
 LABEL "repository"="https://github.com/giantswarm/nancy-fixer"
 
-ADD https://github.com/sonatype-nexus-community/nancy/releases/download/v1.0.46/nancy-v1.0.46-linux-amd64 /usr/local/bin/nancy
+ADD https://github.com/sonatype-nexus-community/nancy/releases/download/v1.0.48/nancy-v1.0.48-linux-amd64 /usr/local/bin/nancy
 RUN chmod a+x /usr/local/bin/nancy
 
 ADD nancy-fixer /usr/local/bin/nancy-fixer

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,6 @@ RUN chmod +x /entrypoint.sh
 
 ENV GOFLAGS=-buildvcs=false
 
+ENV LOG_LEVEL=info
+
 ENTRYPOINT ["/entrypoint.sh"]

--- a/cmd/fix.go
+++ b/cmd/fix.go
@@ -39,6 +39,7 @@ var fixCmd = &cobra.Command{
 		if err != nil {
 			return errors.Cause(err)
 		}
+		logger.Debug("Logging verbosely", logger.Args("level", logger.Level))
 
 		err = fix.Fix(logger, dir)
 		if err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -20,6 +21,7 @@ var rootCmd = &cobra.Command{
 func Execute() {
 	err := rootCmd.Execute()
 	if err != nil {
+		fmt.Printf("Error executing command: %v\n", err)
 		os.Exit(1)
 	}
 }

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,4 +4,4 @@ nancy --version
 nancy-fixer --version
 
 echo "Running nancy-fixer"
-nancy-fixer fix
+nancy-fixer fix --log-level=$LOG_LEVEL


### PR DESCRIPTION
### What does this PR do?

In the giantswarm/devctl repo, executing nancy-fixer in CI failed with exit code 1, without any error message.

This PR adds a `LOG_LEVEL` environment variable and also adds a lot more debug logging in code.

### Any background context you can provide?

https://gigantic.slack.com/archives/C0251MXL5/p1748339780138809

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)
