### PR TITLE
feat(ci): release darwin and windows binaries

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ workflows:
         name: push-to-registries
         requires:
         - go-build
-        platforms: "linux/amd64"
+        platforms: "linux/amd64,linux/arm64"
         filters:
           tags:
             only: /^v.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  architect: giantswarm/architect@9.0.2
+  architect: giantswarm/architect@9.1.0
 
 workflows:
   test:
@@ -11,6 +11,7 @@ workflows:
         name: go-build
         binary: nancy-fixer
         resource_class: large
+        architectures: "linux/amd64,linux/arm64,darwin/amd64,darwin/arm64,windows/amd64,windows/arm64"
         filters:
           tags:
             only: /^v.*/
@@ -20,6 +21,7 @@ workflows:
         name: push-to-registries
         requires:
         - go-build
+        platforms: "linux/amd64"
         filters:
           tags:
             only: /^v.*/
@@ -27,3 +29,14 @@ workflows:
             ignore:
             - main
             - master
+
+    - architect/upload-release-assets:
+        context: architect
+        name: upload-release-assets
+        requires:
+        - go-build
+        filters:
+          branches:
+            ignore: /.*/
+          tags:
+            only: /^v.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,7 @@ workflows:
             - master
 
     - architect/upload-release-assets:
+        binary: nancy-fixer
         context: architect
         name: upload-release-assets
         requires:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Release binaries now include darwin/amd64, darwin/arm64, windows/amd64, and windows/arm64 alongside the existing linux targets. Windows binaries are named `nancy-fixer-windows-<arch>.exe`.
+
 ## [0.7.1] - 2026-03-02
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,19 @@
 FROM gsoci.azurecr.io/giantswarm/golang:1.25.9
 
+ARG TARGETARCH
+
 LABEL "com.github.actions.name"="nancy-fixer-action"
 LABEL "com.github.actions.description"="runs nancy-fixer to patch vulnerabilities found by Nancy"
 LABEL "com.github.actions.icon"="shield"
 LABEL "com.github.actions.color"="orange"
 LABEL "repository"="https://github.com/giantswarm/nancy-fixer"
 
-ADD https://github.com/sonatype-nexus-community/nancy/releases/download/v1.0.52/nancy-v1.0.52-linux-amd64 /usr/local/bin/nancy
-RUN chmod a+x /usr/local/bin/nancy
+# renovate: datasource=github-releases depName=sonatype-nexus-community/nancy
+ARG NANCY_VERSION=v1.0.52
+RUN curl -sSLf https://github.com/sonatype-nexus-community/nancy/releases/download/${NANCY_VERSION}/nancy-${NANCY_VERSION}-linux-${TARGETARCH} -o /usr/local/bin/nancy \
+  && chmod a+x /usr/local/bin/nancy
 
-ADD nancy-fixer /usr/local/bin/nancy-fixer
+COPY nancy-fixer-linux-${TARGETARCH} /usr/local/bin/nancy-fixer
 
 ADD entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh


### PR DESCRIPTION
## What

- `go-build`: adds `darwin/amd64`, `darwin/arm64`, `windows/amd64`, `windows/arm64` to the `architectures` list.
- `upload-release-assets`: uploads signed bare binaries and cosign `.bundle` files to the GitHub Release on tags.
- Bumps architect orb to 9.1.0, which names Windows binaries `<binary>-windows-<arch>.exe` and adds cosign keyless signing and SBOM attestations.

Same pattern as giantswarm/muster#796.

Note: the Dockerfile is not multiarch, so `platforms` on `push-to-registries` is set to `linux/amd64` only. The Dockerfile needs multiarch fixing separately to unlock `linux/arm64` image builds.