### PR TITLE
fix(deps): Change renovate hint format to update nancy version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ LABEL "com.github.actions.icon"="shield"
 LABEL "com.github.actions.color"="orange"
 LABEL "repository"="https://github.com/giantswarm/nancy-fixer"
 
-# renovate: datasource=github-releases depName=sonatype-nexus-community/nancy
+# repo: sonatype-nexus-community/nancy
 ARG NANCY_VERSION=v1.0.52
 RUN curl -sSLf https://github.com/sonatype-nexus-community/nancy/releases/download/${NANCY_VERSION}/nancy-${NANCY_VERSION}-linux-${TARGETARCH} -o /usr/local/bin/nancy \
   && chmod a+x /usr/local/bin/nancy


### PR DESCRIPTION
### What does this PR do?

Changes the renovate hint from using our a custom manager that only matches `_VER` variables to one that should correctly identify this as a github release dependency.
