### PR TITLE
docs: update nancy version to v1.2.0 in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Update nancy to v1.2.0.
 - Release binaries now include darwin/amd64, darwin/arm64, windows/amd64, and windows/arm64 alongside the existing linux targets. Windows binaries are named `nancy-fixer-windows-<arch>.exe`.
 
 ## [0.7.1] - 2026-03-02


### PR DESCRIPTION
### What does this PR do?

Updates the changelog to reflect the new nancy version