### PR TITLE
fix: scan full module graph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Scan the full module graph (`go list -json -m all`) instead of only compiled dependencies (`go list -json -deps ./...`) when detecting vulnerabilities.
+
 ## [0.9.0] - 2026-06-12
 
 ### Changed

--- a/pkg/nancy/nancy.go
+++ b/pkg/nancy/nancy.go
@@ -119,7 +119,7 @@ func RunSleuth(logger *pterm.Logger, dir string) (NancySleuthOutputJSON, error) 
 	r, w := io.Pipe()
 	goCmd := exec.Cmd{
 		Path:   goExecutable,
-		Args:   []string{goExecutable, "list", "-json", "-deps", "./..."},
+		Args:   []string{goExecutable, "list", "-json", "-m", "all"},
 		Dir:    dir,
 		Stdout: w,
 		Stderr: &goStdErr,


### PR DESCRIPTION
### What does this PR do?

Due to https://github.com/sonatype-nexus-community/nancy/issues/305, architect-orb was changed to use `-m all` which counterintuitively shortens the go output passed to nancy, even though it results in scanning more modules.

Because [architect-orb's scans are now scanning more modules](https://github.com/giantswarm/architect-orb/issues/822) than we fix with nancy-fixer, many repositories have failing CI due to vulnerabilities which don't make it into the compiled application, and which will not be fixed automatically.

I don't like this fix, but until the upstream input size restriction is fixed, we'll have to auto-fix the extra vulnerabilities to keep CI moving.
